### PR TITLE
Fix dangling symbolic link error

### DIFF
--- a/private/bundle.sh.tpl
+++ b/private/bundle.sh.tpl
@@ -17,7 +17,7 @@ function copy_blob() {
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
     mkdirp "$(dirname "${dest_path}")"
-    "${COREUTILS}" ln -f "${image_path}/${blob_image_relative_path}" "${dest_path}"
+    "${COREUTILS}" cat "${image_path}/${blob_image_relative_path}" > "${dest_path}"
 }
 
 function create_oci_layout() {


### PR DESCRIPTION
I'm getting a build error on master attempting to build `example/...`:

```
❯ bazel build example/...
INFO: Analyzed 16 targets (0 packages loaded, 0 targets configured).
ERROR: /home/user/code/rule_oci_bundle/example/BUILD.bazel:26:11: error while validating output tree artifact example/bundle: child blobs/sha256/da1f367b9b83905089e31bd02bafdac6e406df391cb49fea7c23c8a2e8461520 is a dangling symbolic link
ERROR: /home/user/code/rule_oci_bundle/example/BUILD.bazel:26:11: OCI Bundle //example:bundle failed: not all outputs were created or valid
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.103s, Critical Path: 0.04s
INFO: 3 processes: 2 internal, 1 linux-sandbox.
ERROR: Build did NOT complete successfully
```

Looking upstream, I discovered this PR in `rules_oci`: https://github.com/bazel-contrib/rules_oci/pull/525

For what it's worth, I'm compiling your project using
```
❯ bazel version
Bazelisk version: v1.19.0
Build label: 7.1.2
Build target: @@//src/main/java/com/google/devtools/build/lib/bazel:BazelServer
Build time: Wed May 8 20:49:55 2024 (1715201395)
Build timestamp: 1715201395
Build timestamp as int: 1715201395

```
